### PR TITLE
don't buffer output, split opts, throw on error

### DIFF
--- a/lib/guard/pytest.rb
+++ b/lib/guard/pytest.rb
@@ -1,6 +1,8 @@
 require 'guard/compat/plugin'
 require 'guard/pytest/version'
 
+require 'shellwords'
+
 module Guard
   class Pytest < Plugin
     def initialize(options = {})
@@ -17,14 +19,22 @@ module Guard
     end
 
     def run_all
-      $stdout.puts `py.test #{options[:pytest_option]}`
+      opts = Shellwords.shellsplit(options[:pytest_option])
+      run_tests(opts)
       true
     end
 
     def run_on_modifications(paths)
-      $stdout.puts `py.test #{options[:pytest_option]} #{paths.join ' '}`
+      opts = Shellwords.shellsplit(options[:pytest_option])
+      run_tests(opts, paths)
       true
     end
 
+    private
+
+    def run_tests(options, files = nil)
+      result = system("py.test", *options, *files)
+      throw(:task_has_failed) unless result
+    end
   end
 end


### PR DESCRIPTION
1. show each test as it's run
2. split pytest options safely
3. correctly notify Guard on failures to stop chained actions
