### PR TITLE
[Feature] Support custom py.test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ guard :pytest, pytest_option: "--doctest-modules --color=yes" do
 end
 ```
 
+specify custom pytest command
+```ruby
+guard :pytest, pytest_cmd: "pipenv run py.test", pytest_option: "--doctest-modules --color=yes" do
+  watch(%r{^((?!test/).*)\.py$})  {|m| "test/#{m[1]}_test.py" }
+  watch(%r{^test/.*_test\.py$})
+end
+```
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/kazufusa/guard-pytest. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.

--- a/lib/guard/pytest.rb
+++ b/lib/guard/pytest.rb
@@ -25,15 +25,18 @@ module Guard
     end
 
     def run_on_modifications(paths)
-      pytest_cmd = options[:pytest_cmd] || "py.test"
       opts = Shellwords.shellsplit(options[:pytest_option])
-      run_tests(pytest_cmd, opts, paths)
+      run_tests(opts, paths)
       true
     end
 
     private
 
-    def run_tests(pytest_cmd, options, files = nil)
+    def pytest_cmd
+      pytest_cmd = options[:pytest_cmd] || "py.test"
+    end
+
+    def run_tests(options, files = nil)
       result = system(pytest_cmd, *options, *files)
       throw(:task_has_failed) unless result
     end

--- a/lib/guard/pytest.rb
+++ b/lib/guard/pytest.rb
@@ -25,15 +25,16 @@ module Guard
     end
 
     def run_on_modifications(paths)
+      pytest_cmd = options[:pytest_cmd] || "py.test"
       opts = Shellwords.shellsplit(options[:pytest_option])
-      run_tests(opts, paths)
+      run_tests(pytest_cmd, opts, paths)
       true
     end
 
     private
 
-    def run_tests(options, files = nil)
-      result = system("py.test", *options, *files)
+    def run_tests(pytest_cmd, options, files = nil)
+      result = system(pytest_cmd, *options, *files)
       throw(:task_has_failed) unless result
     end
   end

--- a/lib/guard/pytest.rb
+++ b/lib/guard/pytest.rb
@@ -34,10 +34,11 @@ module Guard
 
     def pytest_cmd
       pytest_cmd = options[:pytest_cmd] || "py.test"
+      pytest_cmd.split(" ")
     end
 
     def run_tests(options, files = nil)
-      result = system(pytest_cmd, *options, *files)
+      result = system(*pytest_cmd, *options, *files)
       throw(:task_has_failed) unless result
     end
   end

--- a/spec/guard/pytest_spec.rb
+++ b/spec/guard/pytest_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Guard::Pytest do
         subject.run_on_modifications([success_test])
       end
     end
+
+    context "when using customized py.test command" do
+      let(:custom_pytest) { "pipenv run py.test" }
+      subject { Guard::Pytest.new({pytest_option: "--doctest-modules", pytest_cmd: custom_pytest}) }
+      before do
+        allow(subject).to receive(:system).with(custom_pytest , "--doctest-modules", success_test).and_return(true)
+      end
+      it "works" do
+        expect(subject).to receive(:system).with(custom_pytest, "--doctest-modules", success_test).and_return(true)
+        subject.run_on_modifications([success_test])
+      end
+    end
   end
 
   describe "shell expansion" do

--- a/spec/guard/pytest_spec.rb
+++ b/spec/guard/pytest_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe Guard::Pytest do
       let(:custom_pytest) { "pipenv run py.test" }
       subject { Guard::Pytest.new({pytest_option: "--doctest-modules", pytest_cmd: custom_pytest}) }
       before do
-        allow(subject).to receive(:system).with(custom_pytest , "--doctest-modules", success_test).and_return(true)
+        allow(subject).to receive(:system).with("pipenv", "run", "py.test", "--doctest-modules", success_test).and_return(true)
       end
       it "works" do
-        expect(subject).to receive(:system).with(custom_pytest, "--doctest-modules", success_test).and_return(true)
+        expect(subject).to receive(:system).with("pipenv", "run", "py.test", "--doctest-modules", success_test).and_return(true)
         subject.run_on_modifications([success_test])
       end
     end


### PR DESCRIPTION
# Purpose

Allow using custom `py.test` command.
The typical use case is when using `pipenv` the command should be prefixed with `pipenv run`.
Add an optional option `pytest_cmd` to the guard options.

# Changes
- add support for pytest_cmd option
- add test for it
- modify the readme